### PR TITLE
API improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,36 +39,26 @@ Minimal example:
 package main
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 
 	"github.com/dmitryikh/leaves"
 )
 
 func main() {
-	// 1. Open file
-	path := "lightgbm_model.txt"
-	reader, err := os.Open(path)
-	if err != nil {
-		panic(err)
-	}
-	defer reader.Close()
-
-	// 2. Read LightGBM model
-	model, err := leaves.LGEnsembleFromReader(bufio.NewReader(reader))
+	// 1. Read model
+	model, err := leaves.LGEnsembleFromFile("lightgbm_model.txt")
 	if err != nil {
 		panic(err)
 	}
 
-	// 3. Do predictions!
+	// 2. Do predictions!
 	fvals := []float64{1.0, 2.0, 3.0}
 	p := model.Predict(fvals, 0)
 	fmt.Printf("Prediction for %v: %f\n", fvals, p)
 }
 ```
 
-In order to use XGBoost model, just change `leaves.LGEnsembleFromReader`, to `leaves.XGEnsembleFromReader`. For mode usage examples see [leaves_test.go](leaves_test.go).
+In order to use XGBoost model, just change `leaves.LGEnsembleFromFile`, to `leaves.XGEnsembleFromFile`. For mode usage examples see [leaves_test.go](leaves_test.go).
 
 ## Benchmark
 

--- a/leaves.go
+++ b/leaves.go
@@ -5,7 +5,7 @@ const BatchSize = 16
 
 // Ensemble is common interface that every model in leaves should implement
 type Ensemble interface {
-	PredictDense(vals []float64, nrows uint32, ncols uint32, predictions []float64, nTrees int, nThreads int) error
-	PredictCSR(indptr []uint32, cols []uint32, vals []float64, predictions []float64, nTrees int, nThreads int)
+	PredictDense(vals []float64, nrows int, ncols int, predictions []float64, nTrees int, nThreads int) error
+	PredictCSR(indptr []int, cols []int, vals []float64, predictions []float64, nTrees int, nThreads int)
 	Predict(fvals []float64, nTrees int) float64
 }

--- a/leaves.go
+++ b/leaves.go
@@ -1,0 +1,11 @@
+package leaves
+
+// BatchSize for parallel task
+const BatchSize = 16
+
+// Ensemble is common interface that every model in leaves should implement
+type Ensemble interface {
+	PredictDense(vals []float64, nrows uint32, ncols uint32, predictions []float64, nTrees int, nThreads int) error
+	PredictCSR(indptr []uint32, cols []uint32, vals []float64, predictions []float64, nTrees int, nThreads int)
+	Predict(fvals []float64, nTrees int) float64
+}

--- a/leaves_test.go
+++ b/leaves_test.go
@@ -111,7 +111,7 @@ func InnerTestHiggs(t *testing.T, model Ensemble, nThreads int, dense bool, true
 	bufReader := bufio.NewReader(reader)
 	var denseMat DenseMat
 	var csrMat CSRMat
-	var nRows uint32
+	var nRows int
 	if dense {
 		denseMat, err = DenseMatFromLibsvm(bufReader, 0, true)
 		if err != nil {
@@ -312,7 +312,7 @@ func InnerBenchmarkHiggs(b *testing.B, model Ensemble, nThreads int, dense bool)
 	bufReader := bufio.NewReader(reader)
 	var denseMat DenseMat
 	var csrMat CSRMat
-	var nRows uint32
+	var nRows int
 	if dense {
 		denseMat, err = DenseMatFromLibsvm(bufReader, 0, true)
 		if err != nil {

--- a/leaves_test.go
+++ b/leaves_test.go
@@ -29,12 +29,7 @@ func InnerTestLGMSLTR(t *testing.T, nThreads int) {
 
 	// loading model
 	path = filepath.Join("testdata", "lgmsltr.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		t.Skipf("Skipping due to absence of %s", path)
-	}
-	bufReader = bufio.NewReader(reader)
-	model, err := LGEnsembleFromReader(bufReader)
+	model, err := LGEnsembleFromFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,12 +79,7 @@ func InnerTestLGHiggs(t *testing.T, nThreads int) {
 
 	// loading model
 	path = filepath.Join("testdata", "lghiggs.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		t.Skipf("Skipping due to absence of %s", path)
-	}
-	bufReader = bufio.NewReader(reader)
-	model, err := LGEnsembleFromReader(bufReader)
+	model, err := LGEnsembleFromFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,12 +147,7 @@ func InnerTestXGHiggs(t *testing.T, nThreads int, dense bool) {
 
 	// loading model
 	path = filepath.Join("testdata", "xghiggs.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		t.Skipf("Skipping due to absence of %s", path)
-	}
-	bufReader = bufio.NewReader(reader)
-	model, err := XGEnsembleFromReader(bufReader)
+	model, err := XGEnsembleFromFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,12 +199,7 @@ func InnerBenchmarkLGMSLTR(b *testing.B, nThreads int) {
 
 	// loading model
 	path = filepath.Join("testdata", "lgmsltr.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		b.Skipf("Skipping due to absence of %s", path)
-	}
-	bufReader = bufio.NewReader(reader)
-	model, err := LGEnsembleFromReader(bufReader)
+	model, err := LGEnsembleFromFile(path)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -275,12 +255,7 @@ func InnerBenchmarkLGHiggs(b *testing.B, nThreads int, dense bool) {
 
 	// loading model
 	path = filepath.Join("testdata", "lghiggs.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		b.Skipf("Skipping due to absence of %s", path)
-	}
-	bufReader = bufio.NewReader(reader)
-	model, err := LGEnsembleFromReader(bufReader)
+	model, err := LGEnsembleFromFile(path)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -321,13 +296,7 @@ func InnerTestXGAgaricus(t *testing.T, nThreads int) {
 
 	// loading model
 	path = filepath.Join("testdata", "xgagaricus.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	bufReader = bufio.NewReader(reader)
-
-	model, err := XGEnsembleFromReader(bufReader)
+	model, err := XGEnsembleFromFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,12 +369,7 @@ func InnerBenchmarkXGHiggs(b *testing.B, nThreads int, dense bool) {
 
 	// loading model
 	path = filepath.Join("testdata", "xghiggs.model")
-	reader, err = os.Open(path)
-	if err != nil {
-		b.Skipf("Skipping due to absence of %s", path)
-	}
-	bufReader = bufio.NewReader(reader)
-	model, err := XGEnsembleFromReader(bufReader)
+	model, err := XGEnsembleFromFile(path)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/lgensemble.go
+++ b/lgensemble.go
@@ -10,7 +10,7 @@ import (
 // LGEnsemble is LightGBM model (ensemble of trees)
 type LGEnsemble struct {
 	Trees         []lgTree
-	MaxFeatureIdx uint32
+	MaxFeatureIdx int
 }
 
 // NTrees returns number of trees in ensemble
@@ -23,7 +23,7 @@ func (e *LGEnsemble) NTrees() int {
 // return 0.0. Note, that result is a raw score (before sigmoid function
 // transformation and etc)
 func (e *LGEnsemble) Predict(fvals []float64, nTrees int) float64 {
-	if e.MaxFeatureIdx+1 > uint32(len(fvals)) {
+	if e.MaxFeatureIdx+1 > len(fvals) {
 		return 0.0
 	}
 	ret := 0.0
@@ -45,7 +45,7 @@ func (e *LGEnsemble) Predict(fvals []float64, nTrees int) float64 {
 // threads that will be utilized (maximum is GO_MAX_PROCS)
 // Note, that result is a raw score (before sigmoid function transformation and etc).
 // Note, `predictions` slice should be properly allocated on call side
-func (e *LGEnsemble) PredictCSR(indptr []uint32, cols []uint32, vals []float64, predictions []float64, nTrees int, nThreads int) {
+func (e *LGEnsemble) PredictCSR(indptr []int, cols []int, vals []float64, predictions []float64, nTrees int, nThreads int) {
 	nRows := len(indptr) - 1
 	if nRows <= BatchSize || nThreads == 0 || nThreads == 1 {
 		fvals := make([]float64, e.MaxFeatureIdx+1)
@@ -89,18 +89,18 @@ func (e *LGEnsemble) PredictCSR(indptr []uint32, cols []uint32, vals []float64, 
 	wg.Wait()
 }
 
-func (e *LGEnsemble) predictCSRInner(indptr []uint32, cols []uint32, vals []float64, startIndex int, endIndex int, predictions []float64, nTrees int, fvals []float64) {
+func (e *LGEnsemble) predictCSRInner(indptr []int, cols []int, vals []float64, startIndex int, endIndex int, predictions []float64, nTrees int, fvals []float64) {
 	for i := startIndex; i < endIndex; i++ {
 		start := indptr[i]
 		end := indptr[i+1]
 		for j := start; j < end; j++ {
-			if cols[j] < uint32(len(fvals)) {
+			if cols[j] < len(fvals) {
 				fvals[cols[j]] = vals[j]
 			}
 		}
 		predictions[i] = e.Predict(fvals, nTrees)
 		for j := start; j < end; j++ {
-			if cols[j] < uint32(len(fvals)) {
+			if cols[j] < len(fvals) {
 				fvals[cols[j]] = 0.0
 			}
 		}
@@ -113,8 +113,8 @@ func (e *LGEnsemble) predictCSRInner(indptr []uint32, cols []uint32, vals []floa
 // threads that will be utilized (maximum is GO_MAX_PROCS)
 // Note, that result is a raw score (before sigmoid function transformation and etc).
 // Note, `predictions` slice should be properly allocated on call side
-func (e *LGEnsemble) PredictDense(vals []float64, nrows uint32, ncols uint32, predictions []float64, nTrees int, nThreads int) error {
-	nRows := int(nrows)
+func (e *LGEnsemble) PredictDense(vals []float64, nrows int, ncols int, predictions []float64, nTrees int, nThreads int) error {
+	nRows := nrows
 	if ncols == 0 || e.MaxFeatureIdx > ncols-1 {
 		return fmt.Errorf("incorrect number of columns")
 	}

--- a/lgensemble.go
+++ b/lgensemble.go
@@ -7,9 +7,6 @@ import (
 	"sync"
 )
 
-// BatchSize for parallel task
-const BatchSize = 16
-
 // LGEnsemble is LightGBM model (ensemble of trees)
 type LGEnsemble struct {
 	Trees         []lgTree

--- a/lgensemble_io.go
+++ b/lgensemble_io.go
@@ -226,7 +226,7 @@ func LGEnsembleFromReader(reader *bufio.Reader) (*LGEnsemble, error) {
 	if err != nil {
 		return nil, err
 	}
-	e.MaxFeatureIdx = uint32(maxFeatureIdx)
+	e.MaxFeatureIdx = maxFeatureIdx
 
 	treeSizesStr, isFound := params["tree_sizes"]
 	if !isFound {

--- a/lgensemble_io.go
+++ b/lgensemble_io.go
@@ -3,6 +3,7 @@ package leaves
 import (
 	"bufio"
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -247,4 +248,15 @@ func LGEnsembleFromReader(reader *bufio.Reader) (*LGEnsemble, error) {
 		e.Trees = append(e.Trees, tree)
 	}
 	return e, nil
+}
+
+// LGEnsembleFromFile reads LightGBM model from binary file
+func LGEnsembleFromFile(filename string) (*LGEnsemble, error) {
+	reader, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	bufReader := bufio.NewReader(reader)
+	return LGEnsembleFromReader(bufReader)
 }

--- a/lgensemble_test.go
+++ b/lgensemble_test.go
@@ -168,8 +168,8 @@ func TestLGEnsemble(t *testing.T) {
 		math.NaN(), math.NaN(),
 	}
 
-	denseRows := uint32(7)
-	denseCols := uint32(2)
+	denseRows := 7
+	denseCols := 2
 
 	// check predictions
 	predictions := make([]float64, denseRows)

--- a/lgensemble_test.go
+++ b/lgensemble_test.go
@@ -151,13 +151,7 @@ func TestLGTreeLeaves3(t *testing.T) {
 
 func TestLGEnsemble(t *testing.T) {
 	path := filepath.Join("testdata", "model_simple.txt")
-	reader, err := os.Open(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	bufReader := bufio.NewReader(reader)
-
-	model, err := LGEnsembleFromReader(bufReader)
+	model, err := LGEnsembleFromFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mat.go
+++ b/mat.go
@@ -7,15 +7,15 @@ import (
 // DenseMat is dense matrix data structure
 type DenseMat struct {
 	Values []float64
-	Cols   uint32
-	Rows   uint32
+	Cols   int
+	Rows   int
 }
 
 // DenseMatFromArray converts arrays of `values` to DenseMat using shape
 // information `rows` and `cols`
-func DenseMatFromArray(values []float64, rows uint32, cols uint32) (DenseMat, error) {
+func DenseMatFromArray(values []float64, rows int, cols int) (DenseMat, error) {
 	mat := DenseMat{}
-	if uint32(len(values)) != cols*rows {
+	if len(values) != cols*rows {
 		return mat, fmt.Errorf("wrong dimensions")
 	}
 	mat.Values = append(mat.Values, values...)
@@ -26,36 +26,36 @@ func DenseMatFromArray(values []float64, rows uint32, cols uint32) (DenseMat, er
 
 // CSRMat is Compressed Sparse Row matrix data structure
 type CSRMat struct {
-	RowHeaders []uint32
-	ColIndexes []uint32
+	RowHeaders []int
+	ColIndexes []int
 	Values     []float64
 }
 
 // Rows returns number of rows in the matrix
-func (m *CSRMat) Rows() uint32 {
+func (m *CSRMat) Rows() int {
 	if len(m.RowHeaders) == 0 {
 		return 0
 	}
-	return uint32(len(m.RowHeaders)) - 1
+	return len(m.RowHeaders) - 1
 }
 
 // CSRMatFromArray converts arrays of `values` to CSRMat using shape information
 // `rows` and `cols`. See also DenseMatFromArray to store dense data in matrix
-func CSRMatFromArray(values []float64, rows uint32, cols uint32) (CSRMat, error) {
+func CSRMatFromArray(values []float64, rows int, cols int) (CSRMat, error) {
 	mat := CSRMat{}
-	if uint32(len(values)) != cols*rows {
+	if len(values) != cols*rows {
 		return mat, fmt.Errorf("wrong dimensions")
 	}
 	mat.Values = append(mat.Values, values...)
-	mat.ColIndexes = make([]uint32, 0, len(values))
-	mat.RowHeaders = make([]uint32, 0, rows+1)
+	mat.ColIndexes = make([]int, 0, len(values))
+	mat.RowHeaders = make([]int, 0, rows+1)
 
-	for i := uint32(0); i < rows; i++ {
-		mat.RowHeaders = append(mat.RowHeaders, uint32(len(mat.ColIndexes)))
-		for j := uint32(0); j < cols; j++ {
+	for i := 0; i < rows; i++ {
+		mat.RowHeaders = append(mat.RowHeaders, len(mat.ColIndexes))
+		for j := 0; j < cols; j++ {
 			mat.ColIndexes = append(mat.ColIndexes, j)
 		}
 	}
-	mat.RowHeaders = append(mat.RowHeaders, uint32(len(mat.ColIndexes)))
+	mat.RowHeaders = append(mat.RowHeaders, len(mat.ColIndexes))
 	return mat, nil
 }

--- a/mat_io.go
+++ b/mat_io.go
@@ -11,9 +11,9 @@ import (
 // DenseMatFromLibsvm reads dense matrix from libsvm format from `reader`
 // stream. If `limit` > 0, reads only first limit `rows`. First colums is label,
 // and usually you should set `skipFirstColumn` = true
-func DenseMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool) (DenseMat, error) {
+func DenseMatFromLibsvm(reader *bufio.Reader, limit int, skipFirstColumn bool) (DenseMat, error) {
 	mat := DenseMat{}
-	startIndex := uint32(0)
+	startIndex := 0
 	if skipFirstColumn {
 		startIndex = 1
 	}
@@ -31,8 +31,8 @@ func DenseMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool
 			return mat, fmt.Errorf("too few columns")
 		}
 
-		var column uint32
-		for col := startIndex; col < uint32(len(tokens)); col++ {
+		var column int
+		for col := startIndex; col < len(tokens); col++ {
 			if len(tokens[col]) == 0 {
 				break
 			}
@@ -41,7 +41,7 @@ func DenseMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool
 				return mat, fmt.Errorf("can't parse %s", tokens[col])
 			}
 			columnUint64, err := strconv.ParseUint(pair[0], 10, 32)
-			column = uint32(columnUint64)
+			column = int(columnUint64)
 			if err != nil {
 				return mat, fmt.Errorf("can't convert to float %s: %s", pair[0], err.Error())
 			}
@@ -71,13 +71,13 @@ func DenseMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool
 // CSRMatFromLibsvm reads CSR (Compressed Sparse Row) matrix from libsvm format
 // from `reader` stream. If `limit` > 0, reads only first limit `rows`. First
 // colums is label, and usually you should set `skipFirstColumn` = true
-func CSRMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool) (CSRMat, error) {
+func CSRMatFromLibsvm(reader *bufio.Reader, limit int, skipFirstColumn bool) (CSRMat, error) {
 	mat := CSRMat{}
-	startIndex := uint32(0)
+	startIndex := 0
 	if skipFirstColumn {
 		startIndex = 1
 	}
-	rows := uint32(0)
+	rows := 0
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil && err != io.EOF {
@@ -92,9 +92,9 @@ func CSRMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool) 
 			return mat, fmt.Errorf("too few columns")
 		}
 
-		mat.RowHeaders = append(mat.RowHeaders, uint32(len(mat.Values)))
-		var column uint32
-		for col := startIndex; col < uint32(len(tokens)); col++ {
+		mat.RowHeaders = append(mat.RowHeaders, len(mat.Values))
+		var column int
+		for col := startIndex; col < len(tokens); col++ {
 			if len(tokens[col]) == 0 {
 				break
 			}
@@ -103,7 +103,7 @@ func CSRMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool) 
 				return mat, fmt.Errorf("can't parse %s", tokens[col])
 			}
 			columnUint64, err := strconv.ParseUint(pair[0], 10, 32)
-			column = uint32(columnUint64)
+			column = int(columnUint64)
 			if err != nil {
 				return mat, fmt.Errorf("can't convert to float %s: %s", pair[0], err.Error())
 			}
@@ -120,7 +120,7 @@ func CSRMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool) 
 			break
 		}
 	}
-	mat.RowHeaders = append(mat.RowHeaders, uint32(len(mat.Values)))
+	mat.RowHeaders = append(mat.RowHeaders, len(mat.Values))
 	return mat, nil
 }
 
@@ -129,13 +129,13 @@ func CSRMatFromLibsvm(reader *bufio.Reader, limit uint32, skipFirstColumn bool) 
 // is label, and usually you should set `skipFirstColumn` = true. If value is
 // absent `defValue` will be used instead
 func DenseMatFromCsv(reader *bufio.Reader,
-	limit uint32,
+	limit int,
 	skipFirstColumn bool,
 	delimiter string,
 	defValue float64) (DenseMat, error) {
 
 	mat := DenseMat{}
-	startIndex := uint32(0)
+	startIndex := 0
 	if skipFirstColumn {
 		startIndex = 1
 	}
@@ -150,8 +150,8 @@ func DenseMatFromCsv(reader *bufio.Reader,
 		}
 		tokens := strings.Split(line, delimiter)
 
-		var column uint32
-		for col := startIndex; col < uint32(len(tokens)); col++ {
+		var column int
+		for col := startIndex; col < len(tokens); col++ {
 			var value float64
 			if len(tokens[col]) == 0 {
 				value = defValue

--- a/mat_test.go
+++ b/mat_test.go
@@ -84,12 +84,12 @@ func TestCSRMatFromLibsvm(t *testing.T) {
 		t.Errorf("mat.Values incorrect: %s", err.Error())
 	}
 
-	trueRowHeaders := []uint32{0, 3, 5}
+	trueRowHeaders := []int{0, 3, 5}
 	if !reflect.DeepEqual(mat.RowHeaders, trueRowHeaders) {
 		t.Error("mat.RowHeaders are incorrect")
 	}
 
-	trueColIndexes := []uint32{0, 10, 12, 4, 5}
+	trueColIndexes := []int{0, 10, 12, 4, 5}
 	if !reflect.DeepEqual(mat.ColIndexes, trueColIndexes) {
 		t.Error("mat.ColIndexes are incorrect")
 	}
@@ -107,12 +107,12 @@ func TestCSRMatFromLibsvm(t *testing.T) {
 		t.Errorf("mat.Values incorrect: %s", err.Error())
 	}
 
-	trueRowHeaders = []uint32{0, 3}
+	trueRowHeaders = []int{0, 3}
 	if !reflect.DeepEqual(mat.RowHeaders, trueRowHeaders) {
 		t.Error("mat.RowHeaders are incorrect")
 	}
 
-	trueColIndexes = []uint32{0, 10, 12}
+	trueColIndexes = []int{0, 10, 12}
 	if !reflect.DeepEqual(mat.ColIndexes, trueColIndexes) {
 		t.Error("mat.ColIndexes are incorrect")
 	}

--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -3,6 +3,7 @@ package leaves
 import (
 	"bufio"
 	"fmt"
+	"os"
 
 	"github.com/dmitryikh/leaves/internal/xgbin"
 )
@@ -192,4 +193,15 @@ func XGEnsembleFromReader(reader *bufio.Reader) (*XGEnsemble, error) {
 		e.Trees = append(e.Trees, tree)
 	}
 	return e, nil
+}
+
+// XGEnsembleFromFile reads XGBoost model from binary file
+func XGEnsembleFromFile(filename string) (*XGEnsemble, error) {
+	reader, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	bufReader := bufio.NewReader(reader)
+	return XGEnsembleFromReader(bufReader)
 }

--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -19,7 +19,7 @@ func xgIsLeaf(origNode *xgbin.Node) bool {
 	return origNode.CLeft == -1
 }
 
-func xgTreeFromReader(origTree *xgbin.TreeModel, numFeatures uint32) (lgTree, error) {
+func xgTreeFromTreeModel(origTree *xgbin.TreeModel, numFeatures uint32) (lgTree, error) {
 	t := lgTree{}
 
 	if origTree.Param.NumFeature > int32(numFeatures) {
@@ -185,7 +185,7 @@ func XGEnsembleFromReader(reader *bufio.Reader) (*XGEnsemble, error) {
 	// reading particular trees
 	e.Trees = make([]lgTree, 0, nTrees)
 	for i := int32(0); i < nTrees; i++ {
-		tree, err := xgTreeFromReader(origModel.Trees[i], header.Param.NumFeatures)
+		tree, err := xgTreeFromTreeModel(origModel.Trees[i], header.Param.NumFeatures)
 		if err != nil {
 			return nil, fmt.Errorf("error while reading %d tree: %s", i, err.Error())
 		}

--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -156,7 +156,7 @@ func XGEnsembleFromReader(reader *bufio.Reader) (*XGEnsemble, error) {
 	if header.Param.NumFeatures == 0 {
 		return nil, fmt.Errorf("zero number of features")
 	}
-	e.MaxFeatureIdx = header.Param.NumFeatures - 1
+	e.MaxFeatureIdx = int(header.Param.NumFeatures) - 1
 
 	// reading gbtree
 	origModel, err := xgbin.ReadGBTreeModel(reader)


### PR DESCRIPTION
  * Add `LGEnsembleFromFile`/`XGEnsembleFromFile`
  * Add `Ensemble` interface. Helps in tests generalization (#10)
  * Move `uint32` -> `int` in API functions and data structures. `gonum` dense matrix if fully compatible now (#12)
