### PR TITLE
Fix higgs test mismatch on XGBoost

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Single thread:
     * no support transformations functions (sigmoid, lambdarank, etc). Output scores is _raw scores_
   * XGBoost models:
     * no support transformations functions. Output scores is _raw scores_
-	* support only `gbtree` models (most common)
+    * support only `gbtree` models (most common)
+    * could be divergence between C API predictions vs. _leaves_ because of floating point convertions and comparisons tolerances.
 
 ## Contacts
 

--- a/lgtree.go
+++ b/lgtree.go
@@ -86,7 +86,7 @@ func (t *lgTree) predict(fvals []float64) float64 {
 			if node.Flags&rightLeaf > 0 {
 				return t.leafValues[node.Right]
 			}
-			idx = node.Right
+			idx++
 		}
 	}
 }

--- a/utils.go
+++ b/utils.go
@@ -189,6 +189,19 @@ func almostEqualFloat64Slices(a, b []float64, threshold float64) error {
 	return nil
 }
 
+func numMismatchedFloat64Slices(a, b []float64, threshold float64) (int, error) {
+	if len(a) != len(b) {
+		return 0, fmt.Errorf("different sizes: len(a) = %d, len(b) = %d", len(a), len(b))
+	}
+	count := 0
+	for i := range a {
+		if math.Abs(a[i]-b[i]) > threshold {
+			count++
+		}
+	}
+	return count, nil
+}
+
 // Sigmoid applies sigmoid transformation to value
 func Sigmoid(x float64) float64 {
 	return 1.0 / (1.0 + math.Exp(-x))


### PR DESCRIPTION
fix #8 

  * Sometimes here is a problem with float32<->float64 covertations & comparisons tolerances. When decision rule and feature values are very very close to each other.
  * I added maximum number of mismatches to Higgs test.
  * I Added this note to README