### PR TITLE
Lightgbm dart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _leaves_ is a library implementing prediction code for GBRT (Gradient Boosting R
     * support parallel predictions for batches
   * Support LightGBM ([repo](https://github.com/Microsoft/LightGBM)) models:
     * read models from text format
-    * support `gbdt` and `rf` (random forest) models
+    * support `gbdt`, `rf` (random forest) and `dart` models
     * support multiclass predictions
     * addition optimizations for categorical features (for example, _one hot_ decision rule)
     * addition optimizations exploiting only prediction usage

--- a/doc.go
+++ b/doc.go
@@ -185,5 +185,10 @@ Notes on XGBoost DART support
 
 Please note that one must not provide nEstimators = 0 when predict with DART models from xgboost. For more details see xgboost's documentation.
 
+Notes on LightGBM DART support
+
+Models trained with 'boosting_type': 'dart' options can be loaded with func `leaves.LGEnsembleFromFile`.
+But the name of the model (given by `Name()` method) will be 'lightgbm.gbdt', because LightGBM model format doesn't distinguish 'gbdt' and 'dart' models.
+
 */
 package leaves

--- a/leaves_test.go
+++ b/leaves_test.go
@@ -688,3 +688,41 @@ func TestXGDARTAgaricus(t *testing.T) {
 		t.Fatalf("different predictions: %s", err.Error())
 	}
 }
+
+func TestLGDARTBreastCancer(t *testing.T) {
+	testPath := filepath.Join("testdata", "breast_cancer_test.tsv")
+	modelPath := filepath.Join("testdata", "lg_dart_breast_cancer.model")
+	truePath := filepath.Join("testdata", "lg_dart_breast_cancer_true_predictions.txt")
+	skipTestIfFileNotExist(t, testPath, truePath, modelPath)
+
+	// loading test data
+	test, err := mat.DenseMatFromCsvFile(testPath, 0, false, "\t", 0.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// loading model
+	model, err := LGEnsembleFromFile(modelPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// loading true predictions as DenseMat
+	truePredictions, err := mat.DenseMatFromCsvFile(truePath, 0, false, "\t", 0.0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// do predictions
+	predictions := make([]float64, test.Rows*model.NClasses())
+	err = model.PredictDense(test.Values, test.Rows, test.Cols, predictions, 0, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// compare results
+	const tolerance = 1e-6
+	if err := util.AlmostEqualFloat64Slices(truePredictions.Values, predictions, tolerance); err != nil {
+		t.Errorf("different predictions: %s", err.Error())
+	}
+}

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -183,3 +183,6 @@ ds.dump_svmlight_file(test_X, test_Y, 'dermatology_test.libsvm')
 
 ## Iris for LightGBM Random Forest
   1. run testdata/iris_lightgbm_rf.py
+
+## Breast Cancer for LightGBM DART model
+  1. run testdata/lg_dart_breast_cancer.py

--- a/testdata/lg_dart_breast_cancer.py
+++ b/testdata/lg_dart_breast_cancer.py
@@ -1,0 +1,20 @@
+import lightgbm as lgb
+import numpy as np
+from sklearn import datasets
+from sklearn.model_selection import train_test_split
+
+X, y = datasets.load_breast_cancer(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.1, random_state=0)
+
+n_estimators = 10
+d_train = lgb.Dataset(X_train, label=y_train)
+params = {
+    'boosting_type': 'dart',
+    'objective': 'binary',
+}
+clf = lgb.train(params, d_train, n_estimators)
+y_pred = clf.predict(X_test, raw_score=True)
+
+clf.save_model('lg_dart_breast_cancer.model')  # save the model in txt format
+np.savetxt('lg_dart_breast_cancer_true_predictions.txt', y_pred)
+np.savetxt('breast_cancer_test.tsv', X_test, delimiter='\t')


### PR DESCRIPTION
#25 

It seems that lightgbm DART works out of the box because of the lightgbm model format generalization.

Here I added doc&test  on lightgbm DART support.