### PR TITLE
Allow v3 as well

### DIFF
--- a/lgensemble_io.go
+++ b/lgensemble_io.go
@@ -299,7 +299,9 @@ func LGEnsembleFromReader(reader *bufio.Reader, loadTransformation bool) (*Ensem
 	}
 
 	if err := params.Compare("version", "v2"); err != nil {
-		return nil, err
+		if err := params.Compare("version", "v3"); err != nil {
+			return nil, err
+		}
 	}
 	nClasses, err := params.ToInt("num_class")
 	if err != nil {


### PR DESCRIPTION
AFAIK v3 "just" contains additional values for debugging purposes. So at least for the time being it should be possible to allow v3 as well IMHO.