### PR TITLE
adds ability to support multi:softprob for xgboost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dmitryikh/leaves
+module github.com/kgwinnup/leaves
 
 go 1.12

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kgwinnup/leaves
+module github.com/dmitryikh/leaves
 
 go 1.12

--- a/internal/pickle/sklearn.go
+++ b/internal/pickle/sklearn.go
@@ -4,7 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 // SklearnNode represents tree node data structure

--- a/leaves.go
+++ b/leaves.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/dmitryikh/leaves/transformation"
+	"github.com/kgwinnup/leaves/transformation"
 )
 
 // BatchSize for parallel task

--- a/leaves_test.go
+++ b/leaves_test.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dmitryikh/leaves/mat"
-	"github.com/dmitryikh/leaves/transformation"
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/mat"
+	"github.com/kgwinnup/leaves/transformation"
+	"github.com/kgwinnup/leaves/util"
 )
 
 func isFileExists(filename string) bool {

--- a/lgensemble.go
+++ b/lgensemble.go
@@ -1,7 +1,7 @@
 package leaves
 
 import (
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 // lgEnsemble is LightGBM model (ensemble of trees)

--- a/lgensemble_io.go
+++ b/lgensemble_io.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/dmitryikh/leaves/transformation"
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/transformation"
+	"github.com/kgwinnup/leaves/util"
 )
 
 type lgEnsembleJSON struct {

--- a/lgensemble_test.go
+++ b/lgensemble_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 func TestReadLGTree(t *testing.T) {

--- a/lgtree.go
+++ b/lgtree.go
@@ -3,7 +3,7 @@ package leaves
 import (
 	"math"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 const (

--- a/mat/mat_test.go
+++ b/mat/mat_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 func TestDenseMatFromLibsvm(t *testing.T) {

--- a/skensemble_io.go
+++ b/skensemble_io.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dmitryikh/leaves/internal/pickle"
-	"github.com/dmitryikh/leaves/transformation"
+	"github.com/kgwinnup/leaves/internal/pickle"
+	"github.com/kgwinnup/leaves/transformation"
 )
 
 func lgTreeFromSklearnDecisionTreeRegressor(tree pickle.SklearnDecisionTreeRegressor, scale float64, base float64) (lgTree, error) {

--- a/transformation/logistic.go
+++ b/transformation/logistic.go
@@ -3,7 +3,7 @@ package transformation
 import (
 	"fmt"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 type TransformLogistic struct{}

--- a/transformation/softmax.go
+++ b/transformation/softmax.go
@@ -3,7 +3,7 @@ package transformation
 import (
 	"fmt"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 type TransformSoftmax struct {

--- a/transformation/softprob.go
+++ b/transformation/softprob.go
@@ -3,6 +3,7 @@ package transformation
 import (
 	"fmt"
 	"math"
+	"os"
 )
 
 type TransformSoftprob struct {
@@ -14,8 +15,18 @@ func (t *TransformSoftprob) Transform(rawPredictions []float64, outputPrediction
 		return fmt.Errorf("expected len(rawPredictions) = %d (got %d)", t.NClasses, len(rawPredictions))
 	}
 
-	for i, r := range rawPredictions {
-		outputPredictions[i] = (1 / (1 + math.Exp(-r)))
+	fmt.Fprintf(os.Stderr, "%v", rawPredictions)
+
+	sum := 0.0
+
+	for i, v := range rawPredictions {
+		exp := math.Exp(v)
+		outputPredictions[i] = exp
+		sum += exp
+	}
+
+	for i := range outputPredictions {
+		outputPredictions[i] /= sum
 	}
 
 	return nil

--- a/transformation/softprob.go
+++ b/transformation/softprob.go
@@ -1,0 +1,34 @@
+package transformation
+
+import (
+	"fmt"
+	"math"
+)
+
+type TransformSoftprob struct {
+	NClasses int
+}
+
+func (t *TransformSoftprob) Transform(rawPredictions []float64, outputPredictions []float64, startIndex int) error {
+	if len(rawPredictions) != len(outputPredictions) {
+		return fmt.Errorf("expected len(rawPredictions) = %d (got %d)", t.NClasses, len(rawPredictions))
+	}
+
+	for i, r := range rawPredictions {
+		outputPredictions[i] = (1 / (1 + math.Exp(-r)))
+	}
+
+	return nil
+}
+
+func (t *TransformSoftprob) NOutputGroups() int {
+	return t.NClasses
+}
+
+func (t *TransformSoftprob) Type() TransformType {
+	return Softprob
+}
+
+func (t *TransformSoftprob) Name() string {
+	return Softprob.Name()
+}

--- a/transformation/softprob.go
+++ b/transformation/softprob.go
@@ -3,7 +3,6 @@ package transformation
 import (
 	"fmt"
 	"math"
-	"os"
 )
 
 type TransformSoftprob struct {
@@ -14,8 +13,6 @@ func (t *TransformSoftprob) Transform(rawPredictions []float64, outputPrediction
 	if len(rawPredictions) != len(outputPredictions) {
 		return fmt.Errorf("expected len(rawPredictions) = %d (got %d)", t.NClasses, len(rawPredictions))
 	}
-
-	fmt.Fprintf(os.Stderr, "%v", rawPredictions)
 
 	sum := 0.0
 

--- a/transformation/transformation.go
+++ b/transformation/transformation.go
@@ -18,7 +18,8 @@ const (
 	// positive class probabilities
 	Logistic TransformType = 1
 	// Softmax is a TransformType to obtain multiclass probabilities
-	Softmax TransformType = 2
+	Softmax  TransformType = 2
+	Softprob TransformType = 3
 )
 
 func (t TransformType) Name() string {
@@ -26,8 +27,9 @@ func (t TransformType) Name() string {
 		"raw",
 		"logistic",
 		"softmax",
+		"softprob",
 	}
-	if t < Raw || t > Softmax {
+	if t < Raw || t > Softprob {
 		return "unknown"
 	}
 

--- a/xgblinear_io.go
+++ b/xgblinear_io.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dmitryikh/leaves/internal/xgbin"
-	"github.com/dmitryikh/leaves/transformation"
+	"github.com/kgwinnup/leaves/internal/xgbin"
+	"github.com/kgwinnup/leaves/transformation"
 )
 
 // XGBLinearFromReader reads  XGBoost's 'gblinear' model from `reader`

--- a/xgensemble.go
+++ b/xgensemble.go
@@ -3,7 +3,7 @@ package leaves
 import (
 	"math"
 
-	"github.com/dmitryikh/leaves/util"
+	"github.com/kgwinnup/leaves/util"
 )
 
 // xgEnsemble is XGBoost model (ensemble of trees)

--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/dmitryikh/leaves/internal/xgbin"
-	"github.com/dmitryikh/leaves/transformation"
+	"github.com/kgwinnup/leaves/internal/xgbin"
+	"github.com/kgwinnup/leaves/transformation"
 )
 
 func xgSplitIndex(origNode *xgbin.Node) uint32 {

--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -212,6 +212,8 @@ func XGEnsembleFromReader(reader *bufio.Reader, loadTransformation bool) (*Ensem
 	if loadTransformation {
 		if header.NameObj == "binary:logistic" {
 			transform = &transformation.TransformLogistic{}
+		} else if header.NameObj == "multi:softprob" {
+			transform = &transformation.TransformSoftprob{}
 		} else {
 			return nil, fmt.Errorf("unknown transformation function '%s'", header.NameObj)
 		}


### PR DESCRIPTION
allows for use of multi:softprob for xgboost by defining a Softprob transformation and making the appropriate registration in transformation.go. Lastly, adds the transformation loading check for "multi:softprob" when loading an xgboost model. 