### PR TITLE
fix transformation for xgboost model

### DIFF
--- a/xgensemble_io.go
+++ b/xgensemble_io.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/dmitryikh/leaves/internal/xgbin"
 	"github.com/dmitryikh/leaves/transformation"
@@ -212,6 +213,8 @@ func XGEnsembleFromReader(reader *bufio.Reader, loadTransformation bool) (*Ensem
 	if loadTransformation {
 		if header.NameObj == "binary:logistic" {
 			transform = &transformation.TransformLogistic{}
+		} else if strings.HasPrefix(header.NameObj, "multi:soft") {
+			transform = &transformation.TransformSoftmax{NClasses: e.nRawOutputGroups}
 		} else {
 			return nil, fmt.Errorf("unknown transformation function '%s'", header.NameObj)
 		}


### PR DESCRIPTION
This patch fixes the transformation while loading an xgboost model file. When the model file is saved from an xgboost model with param "objective= 'multi:softprob'" or "objective= 'multi:softmax'", the loaded model should use TransformSoftmax rather than TransformRaw. This patch works well on my xgboost model.