### PR TITLE
Return explicit error for predictSingle.

### DIFF
--- a/leaves.go
+++ b/leaves.go
@@ -56,22 +56,22 @@ func (e *Ensemble) checkNEstimators(nEstimators int) error {
 // (trees in most cases) will be used. If `len(fvals)` is not enough function
 // will quietly return 0.0.
 // NOTE: for multiclass or leaf indices predictions use Predict
-func (e *Ensemble) PredictSingle(fvals []float64, nEstimators int) float64 {
+func (e *Ensemble) PredictSingle(fvals []float64, nEstimators int) (float64, error) {
 	if e.NOutputGroups() != 1 {
-		return 0.0
+		return 0.0, fmt.Errorf("you have NOutputGroups more than 1 for a single prediction")
 	}
 	if e.NFeatures() > len(fvals) {
-		return 0.0
+		return 0.0, fmt.Errorf("incorrect number of features (%d)", len(fvals))
 	}
 	nEstimators = e.adjustNEstimators(nEstimators)
-	err := e.checkNEstimators(nEstimators)
-	if err != nil {
-		return 0.0
-	}
-	ret := [1]float64{0.0}
 
+	if e.transform.Type() == transformation.LeafIndex {
+		return 0.0, fmt.Errorf("for leaf indices predictions use Predict")
+	}
+
+	ret := [1]float64{0.0}
 	e.predictInnerAndTransform(fvals, nEstimators, ret[:], 0)
-	return ret[0]
+	return ret[0], nil
 }
 
 // Predict calculates single prediction for one or multiclass ensembles. Only

--- a/leaves_test.go
+++ b/leaves_test.go
@@ -192,7 +192,7 @@ func InnerTestHiggs(t *testing.T, model *Ensemble, nThreads int, isDense bool, t
 		// check single prediction
 		singleIdx := 100
 		fvals := dense.Values[singleIdx*dense.Cols : (singleIdx+1)*dense.Cols]
-		prediction := model.PredictSingle(fvals, 0)
+		prediction, _ := model.PredictSingle(fvals, 0)
 		if err := util.AlmostEqualFloat64Slices([]float64{truePredictions.Values[singleIdx]}, []float64{prediction}, tolerance); err != nil {
 			t.Errorf("different PredictSingle prediction: %s", err.Error())
 		}

--- a/lgensemble_test.go
+++ b/lgensemble_test.go
@@ -221,9 +221,9 @@ func TestLGPredLeaf(t *testing.T) {
 
 	// Test Single
 	fvals := test.Values[:test.Cols]
-	res := model.PredictSingle(fvals, 0)
-	if res != 0.0 {
-		t.Errorf("Failed PredictSingle should return 0.0")
+	_, err = model.PredictSingle(fvals, 0)
+	if err == nil {
+		t.Errorf("PredictSingle should return error for returning leaf indices")
 	}
 
 	// Test Single
@@ -334,7 +334,7 @@ func TestLGEnsembleJSON1tree1leaf(t *testing.T) {
 	}
 
 	features := make([]float64, model.NFeatures())
-	pred := model.PredictSingle(features, 0)
+	pred, _ := model.PredictSingle(features, 0)
 	if pred != 0.42 {
 		t.Fatalf("expected prediction 0.42 (got %f)", pred)
 	}
@@ -365,7 +365,7 @@ func TestLGEnsembleJSON1tree(t *testing.T) {
 	}
 
 	check := func(features []float64, trueAnswer float64) {
-		pred := model.PredictSingle(features, 0)
+		pred, _ := model.PredictSingle(features, 0)
 		if pred != trueAnswer {
 			t.Fatalf("expected prediction %f (got %f)", trueAnswer, pred)
 		}


### PR DESCRIPTION
The PredictSingle returns 0.0 when there is an error, which could be sometimes confusing what is going on unless you read the code.

Maybe it's a good idea to just return the explicit errors, in order to be more friendly for the client code.